### PR TITLE
Jetpack ReQ cost lowered from 15>5

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -956,7 +956,7 @@ CLOTHING
 	contains = list(
 		/obj/item/jetpack_marine,
 	)
-	cost = 15
+	cost = 5
 
 /*******************************************************************************
 MEDICAL


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

ReQ cost change to an item that doesn't really get any use due to its expensive cost

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Jetpacks aren't used by a lot of marines, not because of the drawbacks it has (Lack of backpack storage/second weapon) but because its price in req is way expensive for what it does.
The item doesn't need to be stronger in my opinion, it has already the ability to escape warriors/shrikes brazil abilities and give a nice leap when you need to keep shooting at a target to finish it. That's why lowering the price would maybe make it more usable. A lot of ROs thinks jetpacks are a waste of points. 

At first I wanted to put the jetpack in the vendor to make it consistant but I was afraid it would become a powergaming strategy (we don't want that to happen). 

10 points seems like a large cut because with 105 points you can equip 21 marines with a jetpack instead of 7 but valks/surts/hlin are common and makes that RO is usually left with less than 20 points.
Still, after the changes, if jetpacks are becomming too common a raise to 10 would be more appropriate.

## Changelog
:cl:

balance: rebalanced jetpacks req costs

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
